### PR TITLE
Recursive router

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,61 @@ server.listen(8080, function() {
 
 ```
 
+# Nesting Routers
+
+If you are familiar with Express style routers, you have the ability to nest routers under
+other routers to create a hierarchy of route definitions.
+
+To nest routers use the `.add` method on a Router:
+
+```javascript
+router.add(path, router);
+```
+
+- path - a string path beginning with a forward slash (/)
+    - All routes defined in the provided router will be prefixed with this path during registration
+- router - the router instance to nest
+
+## Example Usage
+
+```javascript
+// routes/v1/auth.js
+
+const router = new Router();
+router.post("/register", function (req, res, next) {
+ // do something with req.body
+ res.send({status: 'success'});
+ return next();
+});
+
+module.exports = router;
+```
+
+```javascript
+// routes/v1/routes.js
+
+const router = new Router();
+router.add("/auth", require("./auth"));
+
+module.exports = router;
+```
+
+```javascript
+// routes/routes.js
+
+const router = new Router();
+router.add("/v1", require("./v1/routes"));
+
+module.exports = router;
+```
+
+With the above router definition from `routes/routes.js` we can do the following call:
+
+`POST /v1/auth/register`
+
+This call is possible because we have nested routers two levels deep from the `/v1` path.
+
+
 # Common Middleware
 
 There may be times when you want to apply some common middleware to all routes registered with a router.

--- a/lib/router.js
+++ b/lib/router.js
@@ -118,11 +118,13 @@ Router.prototype.applyRoutes = function (server, prefix) {
       }
 
       self.routes[method].forEach(function (route) {
-        if (typeof route.options.path === 'string' && prefix !== '') {
-          route.options.path = prefix + route.options.path;
+
+        var options = _.defaults({}, route.options);
+        if (typeof options.path === 'string' && prefix !== '') {
+          options.path = prefix + options.path;
         }
-        server.log.info('Registering %s at uri %s', method.toUpperCase(), route.options.path);
-        server[method](route.options, self.commonHandlers.concat(route.handlers));
+        server.log.info('Registering %s at uri %s', method.toUpperCase(), options.path);
+        server[method](options, self.commonHandlers.concat(route.handlers));
       });
     }
   );

--- a/lib/router.js
+++ b/lib/router.js
@@ -39,6 +39,7 @@ function Router() {
 
   this.routes = routes;
   this.commonHandlers = [];
+  this.routers = [];
 }
 
 /**
@@ -83,6 +84,25 @@ Router.prototype.use = function () {
 };
 
 /**
+ * Nest the routes defined in the given router under the given path
+ *
+ * @param path - String (must begin with a /)
+ * @param router - a Router instance
+ */
+Router.prototype.add = function (path, router) {
+
+  if (typeof path !== 'string') {
+    throw new TypeError('path (string) required');
+  }
+
+  if (!(router instanceof Router)) {
+    throw new TypeError('router (Router) required');
+  }
+
+  this.routers.push({path: path, router: router});
+};
+
+/**
  * Apply all routes from the router to the given restify server instance and adds an optional path prefix
  * @param server
  * @param prefix
@@ -106,6 +126,13 @@ Router.prototype.applyRoutes = function (server, prefix) {
       });
     }
   );
+
+  this.routers.forEach(function (r) {
+    var router = r.router;
+    var path = prefix + r.path;
+    router.use(self.commonHandlers);
+    router.applyRoutes(server, path);
+  });
 };
 
 module.exports = Router;


### PR DESCRIPTION
- A router can now contain other routers; when you apply its routes, it recursively applies routes of the nested routers
- Added basic tests for this functionality

Addresses issue/enhancement #5 

## Usage

```javascript
// routes/routes.js
router.add("/v1", require("./v1/routes"));

// routes/v1/routes.js
router.add("/auth", require("./auth"));

// routes/v1/auth.js
router.post("/register", function (req, res, next) {});
```

@Cyberuben
@Steinweber

Please take a look at the tests under the describe block: `Nested routers via .add` and let me know if this fits your request.

If its good i'll merge it in. It doesn't break existing functionality.

