### PR TITLE
Regex route support with prefixes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -129,6 +129,17 @@ Router.prototype.applyRoutes = function (server, prefix) {
         if (typeof options.path === 'string' && prefix !== '') {
           options.path = prefix + options.path;
         }
+
+        if (options.path instanceof RegExp && prefix !== '') {
+          // Convert prefix into a regular expression:
+          // transform / into \/
+          var slashPattern = new RegExp('\/', 'g');
+          var adjustedPrefixString = prefix.replace(slashPattern, '\\/');
+          // preserve user's ability to describe regex but do prevent it interfering with the prefix match
+          var originalPathRegexString = options.path.source.replace('^', '');
+          options.path = new RegExp(adjustedPrefixString + originalPathRegexString);
+        }
+
         server.log.info('Registering %s at uri %s', method.toUpperCase(), options.path);
         server[method](options, self.commonHandlers.concat(route.handlers));
       });

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -92,6 +92,27 @@ describe('Restify Router', function () {
 
     });
 
+    it('Should add a regex GET route to server when route prefixes are in use', function (done) {
+      var router = new Router();
+
+      router.get(/^\/([a-zA-Z0-9_\.~-]+)\/(.*)/, function (req, res, next) {
+        res.send(req.params[0] + '-' + req.params[1]);
+        next();
+      });
+
+      router.applyRoutes(server, '/nested/example');
+      request(server)
+        .get('/nested/example/hello/test')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          res.body.should.equal('hello-test');
+          done();
+        });
+    });
+
     it('Should add simple POST route to server', function (done) {
 
       var router = new Router();


### PR DESCRIPTION
- Add support for regex routes when using prefixes
- Add test

[Noticed that regex routes were not respecting prefixes](https://github.com/ukayani/restify-router/blob/master/lib/router.js#L129) so made some changes to account for this.