### PR TITLE
Regex support for prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ server.listen(8080, function() {
 
 To prefix all routes, specify the prefix as the second argument to `router.applyRoutes(server, prefix)`
 
+- `prefix` must be a string or a regex
+
 Example:
 
 Routes:
@@ -129,7 +131,7 @@ To nest routers use the `.add` method on a Router:
 router.add(path, router);
 ```
 
-- path - a string path beginning with a forward slash (/)
+- path - a string or regexp path beginning with a forward slash (/)
     - All routes defined in the provided router will be prefixed with this path during registration
 - router - the router instance to nest
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,0 +1,75 @@
+'use strict';
+var assert = require('assert-plus');
+
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(text) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+function toRegex(path) {
+  if (typeof path === 'string') {
+    return new RegExp(escapeRegExp(path));
+  }
+
+  if (path instanceof RegExp) {
+    return path;
+  }
+
+  throw new TypeError('path must be string or RegExp');
+}
+
+function normalize(regexStr) {
+  regexStr = regexStr.replace(/^\^/, ''); // ensure we don't remove cases where ^ has a different purpose, ie. [^xxx]
+  regexStr = regexStr.replace(/\$$/, '');
+  return regexStr;
+}
+
+function addHat(shouldAdd) {
+  if (shouldAdd) {
+    return function (regexStr) {
+      return '^' + regexStr;
+    };
+  } else {
+    return function (regexStr) {
+      return regexStr;
+    };
+  }
+
+}
+
+function addDollar(shouldAdd) {
+  if (shouldAdd) {
+    return function (regexStr) {
+      return regexStr + '$';
+    };
+  } else {
+    return function (regexStr) {
+      return regexStr;
+    };
+  }
+}
+
+function concat(left, right) {
+  if (typeof left === 'string' && typeof right === 'string') {
+    return left + right;
+  }
+
+  var leftR = toRegex(left);
+  var rightR = toRegex(right);
+  var leftSource = leftR.source;
+  var rightSource = rightR.source;
+  var hasHat = leftSource.startsWith('^') || rightSource.startsWith('^');
+  var hasDollar = leftSource.endsWith('$') || rightSource.endsWith('$');
+  var hasIgnoreCase = leftR.ignoreCase || rightR.ignoreCase;
+  var hasGlobal = leftR.global || rightR.global;
+  var hat = addHat(hasHat); // may need to add a hat
+  var dollar = addDollar(hasDollar); // may need to add dollar sign
+
+  var options = (hasIgnoreCase ? 'i' : '') + (hasGlobal ? 'g' : '');
+
+  return new RegExp(dollar(hat(normalize(leftSource) + normalize(rightSource))), options);
+}
+
+module.exports = {
+  concat: concat
+};

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,5 +1,6 @@
 'use strict';
 var assert = require('assert-plus');
+var concat = require('./path').concat;
 
 /**
  * Given a argument list, flatten the list
@@ -97,8 +98,8 @@ Router.prototype.use = function () {
  */
 Router.prototype.add = function (path, router) {
 
-  if (typeof path !== 'string') {
-    throw new TypeError('path (string) required');
+  if (typeof path !== 'string' && !(path instanceof RegExp)) {
+    throw new TypeError('path (string|regexp) required');
   }
 
   if (!(router instanceof Router)) {
@@ -126,9 +127,9 @@ Router.prototype.applyRoutes = function (server, prefix) {
       self.routes[method].forEach(function (route) {
 
         var options = Object.assign({}, route.options);
-        if (typeof options.path === 'string' && prefix !== '') {
-          options.path = prefix + options.path;
-        }
+
+        options.path = concat(prefix, options.path);
+
         server.log.info('Registering %s at uri %s', method.toUpperCase(), options.path);
         server[method](options, self.commonHandlers.concat(route.handlers));
       });
@@ -137,7 +138,7 @@ Router.prototype.applyRoutes = function (server, prefix) {
 
   this.routers.forEach(function (r) {
     var router = r.router;
-    var path = prefix + r.path;
+    var path = concat(prefix, r.path);
     // Prepend commonHandlers before nested router's handlers
     router.commonHandlers = self.commonHandlers.concat(router.commonHandlers);
     router.applyRoutes(server, path);

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -1,0 +1,141 @@
+'use strict';
+var assert = require('assert');
+var concat = require('../lib/path').concat;
+
+describe('.concat', function () {
+  it('should work for two strings as a simple string concatenation', function () {
+    assert(concat('/test', '/foo') === '/test/foo', 'incorrect string concatenation');
+  });
+
+  it('should work for string and RegExp by returning escaped string concatenated with regex', function () {
+    var path = new RegExp('/foo/b[ao]r');
+    var prefix = '/test';
+
+    var concatedPath = concat(prefix, path);
+
+    var samplePath = '/test/foo/bor';
+    var samplePathAlt = '/test/foo/bar';
+
+    assert(samplePath.match(concatedPath) !== null, 'samplePath should match');
+    assert(samplePathAlt.match(concatedPath) !== null, 'samplePathAlt should match');
+
+    var badPath = 'sa/test/foo/boor';
+    assert(badPath.match(concatedPath) === null, 'badPath should not match');
+  });
+
+  it('should work when both paths are RegExp by returning a concatenation', function () {
+    var path = new RegExp('/foo/b[ao]r');
+    var prefix = new RegExp('/te+st');
+
+    var concatedPath = concat(prefix, path);
+
+    var samplePath = '/test/foo/bor';
+    var samplePathAlt = 'sa/teeest/foo/bar';
+
+    assert(samplePath.match(concatedPath) !== null, 'samplePath should match');
+    assert(samplePathAlt.match(concatedPath) !== null, 'samplePathAlt should match');
+
+    var badPath = '/tesst/foo/bor';
+    assert(badPath.match(concatedPath) === null, 'badPath should not match');
+  });
+
+  it('should preserve ^ if either RegExp makes use of it by keeping it as the first character', function () {
+    var path = new RegExp('^/foo/b[ao]r');
+    var prefix = new RegExp('/te+st');
+
+    var concatedPath = concat(prefix, path);
+
+    assert(concatedPath.source.startsWith('^'), 'concatenated path must start with ^');
+
+    var samplePath = '/test/foo/bor';
+    var samplePathAlt = '/teeest/foo/bar';
+
+    assert(samplePath.match(concatedPath) !== null, 'samplePath should match');
+    assert(samplePathAlt.match(concatedPath) !== null, 'samplePathAlt should match');
+
+    var badPath = '/tesst/foo/bor';
+    assert(badPath.match(concatedPath) === null, 'badPath should not match');
+  });
+
+  it('should NOT change ^ if it exist within [] in a RegExp', function () {
+    var path = new RegExp('/foo/b[^ao]r');
+    var prefix = new RegExp('/test');
+
+    var concatedPath = concat(prefix, path);
+
+    assert(!concatedPath.source.startsWith('^'), 'concatenated must not start with ^');
+
+    var samplePath = '/test/foo/bir';
+
+    assert(samplePath.match(concatedPath) !== null, 'samplePath should match');
+  });
+
+  it('should escape regex literals from string paths', function () {
+
+    var path1 = '/test.png';
+    var prefix = new RegExp('^/foo');
+    var concatedPath1 = concat(prefix, path1);
+
+    assert('/foo/test.png'.match(concatedPath1) !== null, 'Unable to match on literal .');
+    assert('/foo/testapng'.match(concatedPath1) === null, 'Literal . was not escaped correctly');
+
+    var path2 = '/test?abc=123';
+    var concatedPath2 = concat(prefix, path2);
+
+    assert('/foo/test?abc=123'.match(concatedPath2) !== null, 'Unable to match on literal ?');
+    assert('/foo/tesabc=123'.match(concatedPath2) === null, 'Literal ? was not escaped correctly');
+
+    var path3 = '/test?abc=$';
+    var concatedPath3 = concat(prefix, path3);
+
+    assert('/foo/test?abc=$'.match(concatedPath3) !== null, 'Unable to match on literal $');
+  });
+
+  it('should fail if path is not a string or RegExp', function () {
+    assert.throws(function () {
+      concat({}, 'test');
+    }, TypeError, 'should not allow objects as paths');
+
+    assert.throws(function () {
+      concat(new RegExp('test'), {});
+    }, TypeError, 'should not allow objects as paths');
+
+    assert.throws(function () {
+      concat({}, {});
+    }, TypeError, 'should not allow objects as paths');
+
+  });
+
+  it('should preserve $ if either RegExp makes use of it by keeping it as the last character', function () {
+    var path = new RegExp('/foo/b[ao]r$');
+    var prefix = new RegExp('/test');
+
+    var concatedPath = concat(prefix, path);
+
+    assert(concatedPath.source.endsWith('$'), 'concatenated path must end with $');
+
+    var samplePath = '/test/foo/bor';
+    var samplePathAlt = '/test/foo/bar';
+
+    assert(samplePath.match(concatedPath) !== null, 'samplePath should match');
+    assert(samplePathAlt.match(concatedPath) !== null, 'samplePathAlt should match');
+
+    var badPath = '/tesst/foo/bor';
+    assert(badPath.match(concatedPath) === null, 'badPath should not match');
+  });
+
+  it('should preserve flags from original RegExps', function () {
+    var path1 = new RegExp('/foo/bar', 'i');
+    var prefix1 = new RegExp('/test', 'g');
+
+    assert(concat(prefix1, path1).global, 'global flag not preserved');
+    assert(concat(prefix1, path1).ignoreCase, 'ignoreCase flag not preserved');
+
+    var path2 = new RegExp('/foo/bar');
+    var prefix2 = '/test';
+
+    assert(concat(prefix2, path2).global === false, 'global flag not preserved');
+    assert(concat(prefix2, path2).ignoreCase === false, 'ignoreCase flag not preserved');
+  });
+});
+

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -92,6 +92,52 @@ describe('Restify Router', function () {
 
     });
 
+    it('Should add simple regex GET route to server with prefix', function (done) {
+
+      var router = new Router();
+
+      router.get(/^\/foo+/, function (req, res, next) {
+        res.send(200);
+        next();
+      });
+
+      router.applyRoutes(server, '/test');
+
+      request(server)
+        .get('/test/foooo')
+        .expect(200)
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        });
+
+    });
+
+    it('Should add simple regex GET route to server with regex prefix', function (done) {
+
+      var router = new Router();
+
+      router.get(/^\/ba+r/, function (req, res, next) {
+        res.send(200);
+        next();
+      });
+
+      router.applyRoutes(server, /\/foo+/);
+
+      request(server)
+        .get('/foooo/baaaar')
+        .expect(200)
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        });
+
+    });
+
     it('Should add simple POST route to server', function (done) {
 
       var router = new Router();
@@ -396,7 +442,10 @@ describe('Restify Router', function () {
       var register = new Router();
 
       register.post('/register', function (req, res, next) {
-        res.send({status: 'success', name: req.body.name});
+        res.send({
+          status: 'success',
+          name: req.body.name
+        });
         return next();
       });
 
@@ -415,7 +464,37 @@ describe('Restify Router', function () {
             return done(err);
           }
 
-          res.body.should.deep.equal({status: 'success', name: 'test'});
+          res.body.should.deep.equal({
+            status: 'success',
+            name: 'test'
+          });
+          done();
+        });
+
+    });
+
+    it('Should allow nesting routers using regex paths', function (done) {
+      var foo = new Router();
+      var bar = new Router();
+      var bam = new Router();
+
+      bam.get('/bam', function (req, res, next) {
+        res.send(200);
+        return next();
+      });
+
+      bar.add(/^\/ba+r/, bam);
+      foo.add(/^\/foo+/, bar);
+
+      foo.applyRoutes(server);
+
+      request(server)
+        .get('/fooo/baar/bam')
+        .expect(200)
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
           done();
         });
 
@@ -431,7 +510,7 @@ describe('Restify Router', function () {
       }
 
       /* jshint ignore:start */
-      expect(fail).to.throw('path (string) required');
+      expect(fail).to.throw('path (string|regexp) required');
       /* jshint ignore:end */
     });
 
@@ -440,7 +519,8 @@ describe('Restify Router', function () {
       function fail() {
         var router = new Router();
 
-        router.add('/foo', function (req, res, next) {});
+        router.add('/foo', function (req, res, next) {
+        });
       }
 
       /* jshint ignore:start */
@@ -476,7 +556,11 @@ describe('Restify Router', function () {
       };
 
       register.post('/register', function (req, res, next) {
-        res.send({status: 'success', name: req.body.name, commonHandlerInjectedValues: req.test});
+        res.send({
+          status: 'success',
+          name: req.body.name,
+          commonHandlerInjectedValues: req.test
+        });
         return next();
       });
 
@@ -497,7 +581,11 @@ describe('Restify Router', function () {
             return done(err);
           }
 
-          res.body.should.deep.equal({status: 'success', name: 'test', commonHandlerInjectedValues: [1,2,3]});
+          res.body.should.deep.equal({
+            status: 'success',
+            name: 'test',
+            commonHandlerInjectedValues: [1, 2, 3]
+          });
           done();
         });
 


### PR DESCRIPTION
- Added support for regular expressions for path prefixes and nested router prefixes
- Fixed issue with prefix not being respected when path is regex
- Added tests for various regex concatenation scenarios as well as router level prefixing with regex

### Regex Concatenation Details
- Addresses various string to regex concatenation issues such as regex literal escaping
- Regex concatenation correctly preserves `^` if present at the start of either prefix or path
- Regex concatenation correctly preserves `$` if present at the end of path
- Regex concatenation preserves the `g` and `i` flags if present in either prefix or path

closes #16 